### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-disk-space.yml
+++ b/.github/workflows/check-disk-space.yml
@@ -5,6 +5,8 @@ on:
     - cron: "0 17 * * *"  # noon EST
   workflow_dispatch:
 
+permissions: {}
+
 env:
   threshold: 80
 


### PR DESCRIPTION
Potential fix for [https://github.com/dandi/backup-status/security/code-scanning/3](https://github.com/dandi/backup-status/security/code-scanning/3)

Add an explicit top-level `permissions` block to `.github/workflows/check-disk-space.yml` so both jobs inherit least-privilege token access.  
Best single fix without changing functionality: set `permissions: {}` at workflow root, since this workflow does not need repository API/token scopes for the shown steps. This is the most restrictive and satisfies CodeQL’s requirement for explicit permissions.

Change location: near the top of the workflow, after `on:` and before `env:` (or any top-level location valid in workflow syntax).

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
