### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-last-update-time.yml
+++ b/.github/workflows/check-last-update-time.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 17 * * *"  # noon EST
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   CheckLastUpdateTime:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/dandi/backup-status/security/code-scanning/4](https://github.com/dandi/backup-status/security/code-scanning/4)

Add an explicit top-level `permissions` block in `.github/workflows/check-last-update-time.yml` so all jobs inherit least-privilege token access.

Best fix here (without changing behavior): set
- `contents: read`  
This is sufficient for the `curl` GitHub API read calls and does not grant write access.

Where to change:
- In `.github/workflows/check-last-update-time.yml`, insert `permissions:` between the `on:` section and `jobs:` section.

No imports, methods, or dependencies are needed (YAML workflow-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
